### PR TITLE
Documentation fix to correct fusee-nano not being installed in base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ When in the configuration menu, you will need to set the following options:
 Target System            => MediaTek Ralink MIPS
 Subtarget                => RT3x5x/RT5350 based boards
 Target Profile           => A5-V11
-Utilities > fusee-nano   => <M>
+Utilities > fusee-nano   => <*>
 ```
 
 4. Compile!


### PR DESCRIPTION
Setting `CONFIG_PACKAGE_fusee-nano=y` appears to fix the issue where the fusee-nano package is not installed in the system image(s).